### PR TITLE
Reduce container image archive size

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Build container image
               run: |
                   podman build --arch arm64 -t ${{ env.IMG_NAME }} .
-                  podman save ${{ env.IMG_NAME }} -o ${{ env.IMG_NAME }}.tar
+                  podman save ${{ env.IMG_NAME }} --format oci-archive -o ${{ env.IMG_NAME }}.tar
             - name: Upload Docker image to VPS using ssh
               uses: easingthemes/ssh-deploy@v5.1.0
               with:

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/oven/bun:alpine as BUILDER
+FROM docker.io/oven/bun:1.1.26-alpine as BUILDER
 
 WORKDIR /builder
 
@@ -8,7 +8,7 @@ RUN bun install --frozen-lockfile
 RUN bun run build
 
 #############################################
-FROM docker.io/oven/bun:alpine
+FROM docker.io/oven/bun:1.1.26-alpine
 
 USER nobody
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "bun src/index.ts",
 		"dev:hot": "bun --hot src/index.ts",
-		"build": "bun build ./src/index.ts --outdir ./out --target bun",
+		"build": "bun build ./src/index.ts --outdir ./out --minify --sourcemap --target bun",
 		"format": "prettier -c .",
 		"format:fix": "prettier -w .",
 		"lint": "eslint .",


### PR DESCRIPTION
Can't fix the real img size due to bun's binary being ~80MB, but compressed image archive is possible.
fixes #39 